### PR TITLE
Fix: Disable SSL warnings

### DIFF
--- a/atoto_fw/core/http.py
+++ b/atoto_fw/core/http.py
@@ -2,7 +2,6 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 import urllib3
 
-# Disable SSL warnings
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 UA   = "ATOTO-Firmware-CLI/3.2"
@@ -18,7 +17,7 @@ def make_session() -> requests.Session:
     s = requests.Session()
     s.mount("http://", adapter); s.mount("https://", adapter)
     s.headers.update({"User-Agent": UA})
-    s.verify = False  # Disable SSL certificate verification
+    s.verify = False
     return s
 
 SESSION = make_session()

--- a/atoto_fw/core/http.py
+++ b/atoto_fw/core/http.py
@@ -1,5 +1,9 @@
 import requests
 from requests.adapters import HTTPAdapter, Retry
+import urllib3
+
+# Disable SSL warnings
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 UA   = "ATOTO-Firmware-CLI/3.2"
 
@@ -14,6 +18,7 @@ def make_session() -> requests.Session:
     s = requests.Session()
     s.mount("http://", adapter); s.mount("https://", adapter)
     s.headers.update({"User-Agent": UA})
+    s.verify = False  # Disable SSL certificate verification
     return s
 
 SESSION = make_session()


### PR DESCRIPTION
Running the downloader now results in an error:

`ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:992)`

Modified `http.py` to disable SSL verification and silence warnings.